### PR TITLE
Don't run clang-only libbdsg make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(INC_DIR)/mio/mmap.hpp:
 	cd $(DEP_DIR)/mio && mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$(CWD) .. && $(MAKE) install && cd $(CWD)
 
 $(LIB_DIR)/libbdsg.a: $(LIB_DIR)/libhandlegraph.a $(LIB_DIR)/libsdsl.a $(INC_DIR)/sparsepp/spp.h $(INC_DIR)/dynamic/dynamic.h $(INC_DIR)/BooPHF.h $(INC_DIR)/mio/mmap.hpp
-	cd $(DEP_DIR)/libbdsg && CPLUS_INCLUDE_PATH=$(CWD)/$(INC_DIR):$(CPLUS_INCLUDE_PATH) LIBRARY_PATH=$(CWD)/$(LIB_DIR):$(LIBRARY_PATH) $(MAKE) test && cp lib/libbdsg.a $(CWD)/$(LIB_DIR) && cp -r bdsg/include/* $(CWD)/$(INC_DIR) && cd $(CWD)
+	cd $(DEP_DIR)/libbdsg && CPLUS_INCLUDE_PATH=$(CWD)/$(INC_DIR):$(CPLUS_INCLUDE_PATH) LIBRARY_PATH=$(CWD)/$(LIB_DIR):$(LIBRARY_PATH) $(MAKE) && cp lib/libbdsg.a $(CWD)/$(LIB_DIR) && cp -r bdsg/include/* $(CWD)/$(INC_DIR) && cd $(CWD)
 
 # run .pre-build before we make anything at all.
 -include .pre-build


### PR DESCRIPTION
This is just a quick fix to get it to build on recent Ubuntus. 

A better fix would be to update to the latest libbdsg (where -lomp is pushed into a darwin-only build path).  But that trips up a bunch of other json-related dependencies. 

It also looks like the latest libbdsg comes with its own submodules (but not the required json).  So once that's fixed, perhaps there's no more need for libbdsg-easy anyway...