### PR TITLE
Fix compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ $(INC_DIR)/dynamic/dynamic.h:
 	mkdir -p $(INC_DIR)/dynamic/
 	cp -r $(DEP_DIR)/DYNAMIC/include/* $(INC_DIR)/
 	# annoyingly doesn't have an install option on the cmake, so we manually move their external dependency headers
-	cd $(DEP_DIR)/DYNAMIC && mkdir -p build && cd build && cmake .. && $(MAKE) && cp -r hopscotch_map-prefix/src/hopscotch_map/include/* $(CWD)/$(INC_DIR) && cd $(CWD)
+	cd $(DEP_DIR)/DYNAMIC && mkdir -p build && cd build && cmake .. && $(MAKE) && cp -r ../deps/hopscotch_map/include/* $(CWD)/$(INC_DIR) && cd $(CWD)
 
 $(INC_DIR)/BooPHF.h:
 	cp $(DEP_DIR)/BBHash/BooPHF.h $(INC_DIR)


### PR DESCRIPTION
Hi,
I was having a problem during compilation (creation of `lib/libbdsg.a` was failing). I tracked the error to a wrong `cp` from the `hopscotch_map` submodule in the Makefile (in one of the latest commits, that folder was moved around while including `hopscotch_map` as submodule). Here the fixed Makefile.

Best,